### PR TITLE
Get path to db from env

### DIFF
--- a/hn_bot
+++ b/hn_bot
@@ -130,7 +130,8 @@ def publish_to_reddit(thing, sub="hackernews"):
         _LOG.error("mysterious error deep within PRAW/json: %s" % e)
 
 import shelve
-URLS_POSTED = shelve.open(".hn_bot.shelve")
+import os
+URLS_POSTED = shelve.open(os.getenv("database_file",".hn_bot.shelve"))
 
 for thing in get_hn_items():
     if thing.url in URLS_POSTED:


### PR DESCRIPTION
This change allows a user to pull the path to store the shelve file from an environment variable. Using an environment variable is optional and will default to the current directory as `.hn_bot.shelve` (as currently implemented).

This goes hand in hand with the docker setup for this bot, allowing the path to be separate from the bot's location thus we can persist the file while being able to update he code.

Fixes: https://github.com/fletchto99/hn-bot-docker/pull/2